### PR TITLE
Fix possible messages not being logged

### DIFF
--- a/NutsLogger.swift
+++ b/NutsLogger.swift
@@ -3,6 +3,7 @@ func NutsLogger(@autoclosure message: () -> String) {
     if _isDebugAssertConfiguration() {
         if random() % 50 == 0 {
             print("peanuts trace")
+            NutsLogger(message)
         }
 	else {
             print(message())


### PR DESCRIPTION
In case a peanut trace is logged, the original message gets lost because of the else.
